### PR TITLE
Make parsing of hardware map files a bit more robust

### DIFF
--- a/src/HardwareMapService.cpp
+++ b/src/HardwareMapService.cpp
@@ -26,7 +26,7 @@ HardwareMapService::HardwareMapService(const std::string filename)
   std::string line;
   while (std::getline(inFile, line)) {
     HWInfo hw_info;
-    if (line.size() == 0 || line[0] == '#')
+    if (line.size() == 0 || line[line.find_first_not_of(" \t")] == '#')
       continue;
     std::stringstream linestream(line);
     linestream >> hw_info.dro_source_id >> hw_info.det_link >> hw_info.det_slot >> hw_info.det_crate >>


### PR DESCRIPTION
by allowing spaces before a '#' in the case of commented lines. `>>` is smart
enough not to care so leading spaces (which can happen when copying and pasting and are not always easily seen) do not matter for the rest of the lines.