### PR TITLE
Adding function for TCPChannelMap inverse mapping

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(detchannelmaps VERSION 1.4.0)
+project(detchannelmaps VERSION 1.4.1)
 
 find_package(daq-cmake REQUIRED)
 find_package(cetlib REQUIRED)   # Uses the daq-buildtools/cmake/Findcetlib.cmake

--- a/include/detchannelmaps/TPCChannelMap.hpp
+++ b/include/detchannelmaps/TPCChannelMap.hpp
@@ -4,6 +4,7 @@
 #include "cetlib/BasicPluginFactory.h"
 #include "cetlib/compiler_macros.h"
 #include "ers/Issue.hpp"
+#include <optional>
 
 
 #ifndef EXTERN_C_FUNC_DECLARE_START
@@ -44,18 +45,27 @@ class TPCChannelMap
 {
 public:
 
+  struct TPCCoords
+  {
+    uint crate;
+    uint slot;
+    uint fiber;
+    uint channel;
+  };
+
   /**
    * @brief      Gets the offline channel from detector elements.
    *
    * @param[in]  crate        The crate
    * @param[in]  slot         The slot
    * @param[in]  fiber        The fiber
-   * @param[in]  fembchannel  The fembchannel
+   * @param[in]  fembchannel  The channel
    *
    * @return     The offline channel from detector elements.
    */
-  virtual uint get_offline_channel_from_crate_slot_fiber_chan(uint crate, uint slot, uint fiber, uint fembchannel) = 0;
+  virtual uint get_offline_channel_from_crate_slot_fiber_chan(uint crate, uint slot, uint fiber, uint channel) = 0;
   virtual uint get_plane_from_offline_channel(uint offchannel) = 0;
+  virtual std::optional<TPCCoords> get_crate_slot_fiber_chan_from_offline_channel(uint offchannel) = 0;
   /**
    * @brief TPCChannelMap destructor
    */

--- a/plugins/HDColdboxChannelMap.cpp
+++ b/plugins/HDColdboxChannelMap.cpp
@@ -26,7 +26,8 @@ public:
   HDColdboxChannelMap(HDColdboxChannelMap&&) = delete;                 ///< HDColdboxChannelMap is not move-constructible
   HDColdboxChannelMap& operator=(HDColdboxChannelMap&&) = delete;      ///< HDColdboxChannelMap is not move-assignable
 
-  uint get_offline_channel_from_crate_slot_fiber_chan(uint crate, uint slot, uint link, uint wibframechan) final {
+  uint
+  get_offline_channel_from_crate_slot_fiber_chan(uint crate, uint slot, uint link, uint wibframechan) final {
 
     auto chan_info = m_channel_map->GetChanInfoFromWIBElements(
         crate, slot, link, wibframechan
@@ -40,7 +41,9 @@ public:
 
   }
 
-  uint get_plane_from_offline_channel(uint offchannel) final {
+
+  uint
+  get_plane_from_offline_channel(uint offchannel) final {
     auto chan_info = m_channel_map->GetChanInfoFromOfflChan(offchannel);
 
     if (!chan_info.valid) {
@@ -49,6 +52,17 @@ public:
 
     return chan_info.plane;
   };
+
+
+  std::optional<TPCCoords> 
+  get_crate_slot_fiber_chan_from_offline_channel(uint offchannel) {
+    auto ci = m_channel_map->GetChanInfoFromOfflChan(offchannel);
+
+    if ( !ci.valid) {
+      return std::nullopt;
+    }
+    return TPCCoords{ci.crate, ci.wib-1, ci.link, ci.wibframechan};
+  }
 
 private:
 

--- a/plugins/PD2HDChannelMap.cpp
+++ b/plugins/PD2HDChannelMap.cpp
@@ -9,7 +9,9 @@ namespace detchannelmaps {
 class PD2HDChannelMap :  public TPCChannelMap
 {
 public:
+
   explicit PD2HDChannelMap() {
+  
     const char* detchannelmaps_share_cstr = getenv("DETCHANNELMAPS_SHARE");
     if (!detchannelmaps_share_cstr) {
       throw std::runtime_error("Environment variable DETCHANNELMAPS_SHARE is not set");
@@ -26,7 +28,9 @@ public:
   PD2HDChannelMap(PD2HDChannelMap&&) = delete;                 ///< PD2HDChannelMap is not move-constructible
   PD2HDChannelMap& operator=(PD2HDChannelMap&&) = delete;      ///< PD2HDChannelMap is not move-assignable
 
-  uint get_offline_channel_from_crate_slot_fiber_chan(uint crate, uint slot, uint link, uint wibframechan) final {
+
+  uint 
+  get_offline_channel_from_crate_slot_fiber_chan(uint crate, uint slot, uint link, uint wibframechan) final {
 
     auto chan_info = m_channel_map->GetChanInfoFromWIBElements(
         crate, slot, link, wibframechan
@@ -40,7 +44,9 @@ public:
 
   }
 
-  uint get_plane_from_offline_channel(uint offchannel) final {
+
+  uint 
+  get_plane_from_offline_channel(uint offchannel) final {
     auto chan_info = m_channel_map->GetChanInfoFromOfflChan(offchannel);
 
     if (!chan_info.valid) {
@@ -49,6 +55,19 @@ public:
 
     return chan_info.plane;
   };
+
+
+  std::optional<TPCCoords> 
+  get_crate_slot_fiber_chan_from_offline_channel(uint offchannel) {
+    auto ci = m_channel_map->GetChanInfoFromOfflChan(offchannel);
+
+    if ( !ci.valid) {
+      return std::nullopt;
+    }
+    return TPCCoords{ci.crate, ci.wib-1, ci.link, ci.wibframechan};
+  }
+
+
 
 private:
 

--- a/plugins/ProtoDUNESP1ChannelMap.cpp
+++ b/plugins/ProtoDUNESP1ChannelMap.cpp
@@ -41,6 +41,10 @@ public:
     return m_channel_map->PlaneFromOfflineChannel(offchannel);
   };
 
+  std::optional<TPCCoords> 
+  get_crate_slot_fiber_chan_from_offline_channel(uint offchannel) {
+    return std::nullopt;
+  }
 private:
 
   std::unique_ptr<PdspChannelMapService> m_channel_map;

--- a/plugins/ProtoDUNESP1ChannelMap.cpp
+++ b/plugins/ProtoDUNESP1ChannelMap.cpp
@@ -36,7 +36,7 @@ public:
 
             uint off_chan = get_offline_channel_from_crate_slot_fiber_chan(i_crate, i_slots, i_fiber, i_chan);
             
-            std::cout << off_chan << "   " << i_crate << "   " <<  i_slots <<  "   " << i_fiber << std::endl;
+            // std::cout << off_chan << "   " << i_crate << "   " <<  i_slots <<  "   " << i_fiber << std::endl;
             m_offchan_to_coords_map[off_chan] = TPCCoords{i_crate, i_slots, i_fiber, i_chan};
           }
         }

--- a/plugins/ProtoDUNESP1ChannelMap.cpp
+++ b/plugins/ProtoDUNESP1ChannelMap.cpp
@@ -7,15 +7,41 @@ namespace detchannelmaps {
 class ProtoDUNESP1ChannelMap :  public TPCChannelMap
 {
 public:
+
+
+
   explicit ProtoDUNESP1ChannelMap() {
+
+    // Find the map configuration file
     const char* detchannelmaps_share_cstr = getenv("DETCHANNELMAPS_SHARE");
     if (!detchannelmaps_share_cstr) {
       throw std::runtime_error("Environment variable DETCHANNELMAPS_SHARE is not set");
     }
+    // Create search paths
     std::string detchannelmaps_share(detchannelmaps_share_cstr);
     std::string channel_map_rce = detchannelmaps_share + "/config/protodunesp1/protoDUNETPCChannelMap_RCE_v4.txt";
     std::string channel_map_felix = detchannelmaps_share + "/config/protodunesp1/protoDUNETPCChannelMap_FELIX_v4.txt";
+    // Instantiate paths
     m_channel_map.reset(new PdspChannelMapService(channel_map_rce, channel_map_felix));
+
+    // Create reverse maps
+    // Loop over crates (0-5)
+    for (uint i_crate(0); i_crate < m_n_crates; ++i_crate) {
+      // Loop over (0-4)
+      for (uint i_slots(0); i_slots < m_n_slots; ++i_slots) {
+        // Loop over fibres (1,2)
+        for (uint i_fiber(1); i_fiber <= m_n_fibers; ++i_fiber) {
+          // Loop over channels (0-255)
+          for (uint i_chan(0); i_chan < m_n_chans; ++i_chan) {
+
+            uint off_chan = get_offline_channel_from_crate_slot_fiber_chan(i_crate, i_slots, i_fiber, i_chan);
+            
+            std::cout << off_chan << "   " << i_crate << "   " <<  i_slots <<  "   " << i_fiber << std::endl;
+            m_offchan_to_coords_map[off_chan] = TPCCoords{i_crate, i_slots, i_fiber, i_chan};
+          }
+        }
+      }
+    }
   }
 
   ProtoDUNESP1ChannelMap(const ProtoDUNESP1ChannelMap&) = delete;            ///< ProtoDUNESP1ChannelMap is not copy-constructible
@@ -43,11 +69,25 @@ public:
 
   std::optional<TPCCoords> 
   get_crate_slot_fiber_chan_from_offline_channel(uint offchannel) {
-    return std::nullopt;
+
+    auto it = m_offchan_to_coords_map.find(offchannel);
+
+    if ( it == m_offchan_to_coords_map.end() )
+      return std::nullopt;
+
+    return it->second;
   }
+
 private:
+  
+  const size_t m_tot_chans = 15360;
+  const size_t m_n_crates = 6;
+  const size_t m_n_slots = 5;
+  const size_t m_n_fibers = 2;
+  const size_t m_n_chans = 256;
 
   std::unique_ptr<PdspChannelMapService> m_channel_map;
+  std::map<uint, TPCCoords> m_offchan_to_coords_map;
 
   
 };

--- a/plugins/VDColdboxChannelMap.cpp
+++ b/plugins/VDColdboxChannelMap.cpp
@@ -50,6 +50,33 @@ public:
     return chan_info.plane;
   };
 
+  // std::optional<TPCCoords> 
+  // get_crate_slot_fiber_chan_from_offline_channel(uint offchannel) {
+  //   auto ci = m_channel_map->getChanInfoFromOfflChan(offchannel);
+
+  //   // return ci.valid ? std::optional<TPCCoords>{4, ci.wib-1, (ci.wibconnector+1)/2, ci.cebchan} : std::nullopt;
+  //   return std::nullopt;
+  // }
+
+  std::optional<TPCCoords> 
+  get_crate_slot_fiber_chan_from_offline_channel(uint offchannel) {
+    auto ci = m_channel_map->getChanInfoFromOfflChan(offchannel);
+
+    if ( !ci.valid) {
+      return std::nullopt;
+    }
+    // wc = (fiber*2 - 1) + (chan > 127);
+    // cechan = chan % 128
+
+    // ((wc+1) % 2) == 0 //
+
+    // fibre = 1 -> wc = 1 (0-127),2 (0-127)
+    // fibre = 2 -> wc = 3,4
+
+
+    // std::cout << ci.wib << "   " << ci.wibconnector << "   " <<  ci.cebchan <<  std::endl;
+    return TPCCoords{4, ci.wib-1, (ci.wibconnector+1)/2, ci.cebchan+128*((ci.wibconnector+1)%2)};
+  }
 private:
 
   std::unique_ptr<dune::PD2HDChannelMapSP> m_channel_map;

--- a/plugins/VDColdboxChannelMap.cpp
+++ b/plugins/VDColdboxChannelMap.cpp
@@ -58,24 +58,34 @@ public:
   //   return std::nullopt;
   // }
 
+//  std::optional<TPCCoords> 
+//  get_crate_slot_fiber_chan_from_offline_channel(uint offchannel) {
+//    auto ci = m_channel_map->GetChanInfoFromOfflChan(offchannel);
+//
+//    if ( !ci.valid) {
+//      return std::nullopt;
+//    }
+//    // wc = (fiber*2 - 1) + (chan > 127);
+//    // cechan = chan % 128
+//
+//    // ((wc+1) % 2) == 0 //
+//
+//    // fibre = 1 -> wc = 1 (0-127),2 (0-127)
+//    // fibre = 2 -> wc = 3,4
+//
+//
+//    // std::cout << ci.wib << "   " << ci.wibconnector << "   " <<  ci.cebchan <<  std::endl;
+//    return TPCCoords{4, ci.wib-1, (ci.wibconnector+1)/2, ci.cebchan+128*((ci.wibconnector+1)%2)};
+//  }
+//
   std::optional<TPCCoords> 
   get_crate_slot_fiber_chan_from_offline_channel(uint offchannel) {
-    auto ci = m_channel_map->getChanInfoFromOfflChan(offchannel);
+    auto ci = m_channel_map->GetChanInfoFromOfflChan(offchannel);
 
     if ( !ci.valid) {
       return std::nullopt;
     }
-    // wc = (fiber*2 - 1) + (chan > 127);
-    // cechan = chan % 128
-
-    // ((wc+1) % 2) == 0 //
-
-    // fibre = 1 -> wc = 1 (0-127),2 (0-127)
-    // fibre = 2 -> wc = 3,4
-
-
-    // std::cout << ci.wib << "   " << ci.wibconnector << "   " <<  ci.cebchan <<  std::endl;
-    return TPCCoords{4, ci.wib-1, (ci.wibconnector+1)/2, ci.cebchan+128*((ci.wibconnector+1)%2)};
+    return TPCCoords{ci.crate, ci.wib-1, ci.link, ci.wibframechan};
   }
 private:
 

--- a/pybindsrc/channelmap.cpp
+++ b/pybindsrc/channelmap.cpp
@@ -23,9 +23,18 @@ void
 register_maps(py::module& m)
 {
 
+  py::class_<TPCChannelMap::TPCCoords>(m, "TPCCoords")
+    .def(py::init<uint, uint, uint, uint>())
+    .def_readwrite("crate", &TPCChannelMap::TPCCoords::crate)
+    .def_readwrite("slot", &TPCChannelMap::TPCCoords::slot)
+    .def_readwrite("fiber", &TPCChannelMap::TPCCoords::fiber)
+    .def_readwrite("channel", &TPCChannelMap::TPCCoords::channel)
+  ;
+
   py::class_<TPCChannelMap, std::shared_ptr<TPCChannelMap>>(m, "TPCChannelMap")
     .def("get_plane_from_offline_channel", &TPCChannelMap::get_plane_from_offline_channel)
     .def("get_offline_channel_from_crate_slot_fiber_chan", &TPCChannelMap::get_offline_channel_from_crate_slot_fiber_chan)
+    .def("get_crate_slot_fiber_chan_from_offline_channel", &TPCChannelMap::get_crate_slot_fiber_chan_from_offline_channel)
   ;
 
   m.def("make_map", &make_map);

--- a/test/plugins/DummyChannelMap.cpp
+++ b/test/plugins/DummyChannelMap.cpp
@@ -48,6 +48,10 @@ public:
     return 2;
   }
 
+  std::optional<TPCCoords> 
+  get_crate_slot_fiber_chan_from_offline_channel(uint offchannel) {
+    return TPCCoords{1, 2, 3, 4};
+  }
 
 };
 


### PR DESCRIPTION
Introduced the `get_crate_slot_fiber_chan_from_offline_channel` method that enables mapping an offline channel to crate, slot, link, channel