### PR TITLE
Commented out the daq_codegen statement from CMakeLists.txt since the…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ find_package(Boost COMPONENTS unit_test_framework REQUIRED)
 
 daq_setup_environment()
 
-daq_codegen( *.jsonnet TEMPLATES Structs.hpp.j2 Nljs.hpp.j2 )
+#daq_codegen( *.jsonnet TEMPLATES Structs.hpp.j2 Nljs.hpp.j2 )
 
 ##############################################################################
 # Main library


### PR DESCRIPTION
…re don't seem to be any jsonnet files in this repo (and removing it helps things compile in certain situations).

The following steps produce a software area that does not build:

```
source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
setup_dbt latest
dbt-create -c -n NAFD23-11-08 08NovFDDevTest1
cd 08NovFDDevTest1/sourcecode
git clone https://github.com/DUNE-DAQ/daqconf.git -b develop
git clone https://github.com/DUNE-DAQ/daqsystemtest.git -b develop
git clone https://github.com/DUNE-DAQ/dfmodules.git -b develop
git clone https://github.com/DUNE-DAQ/fddaqconf.git -b develop
git clone https://github.com/DUNE-DAQ/detchannelmaps.git -b develop
cd ..
dbt-workarea-env
dbt-build -j 20
dbt-workarea-env
```

The complaint is 
```
CMake Error in dfmodules/CMakeLists.txt:
  Imported target "trigger::trigger" includes non-existent path

    "/home/nfs/biery/dunedaq/08NovFDDevTest1/build/detchannelmaps/codegen/include"

  in its INTERFACE_INCLUDE_DIRECTORIES.  Possible reasons include:

  * The path was deleted, renamed, or moved to another location.

  * An install or uninstall procedure did not complete successfully.

  * The installation package was faulty and references files it does not
  provide.

```

Using this branch in detchannelmaps allows the build to succeed.

It would be great for someone to confirm that removing the codegen line from the CMakeLists.txt file is a reasonable thing to do.