### PR TITLE
JCF: similar to how adding a dependency to CMakeLists.txt means it sh…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,6 @@ find_package(daq-cmake REQUIRED)
 find_package(cetlib REQUIRED)   # Uses the daq-buildtools/cmake/Findcetlib.cmake
 find_package(ers REQUIRED)
 find_package(logging REQUIRED)
-#find_package(serialization REQUIRED)
 find_package(Boost COMPONENTS unit_test_framework REQUIRED)
 
 daq_setup_environment()
@@ -15,7 +14,7 @@ daq_setup_environment()
 ##############################################################################
 # Main library
 
-daq_add_library(*.cpp LINK_LIBRARIES ${CETLIB} ${CETLIB_EXCEPT} ers::ers logging::logging) # serialization::serialization)
+daq_add_library(*.cpp LINK_LIBRARIES ${CETLIB} ${CETLIB_EXCEPT} ers::ers logging::logging) 
 
 ##############################################################################
 # Python bindings

--- a/cmake/detchannelmapsConfig.cmake.in
+++ b/cmake/detchannelmapsConfig.cmake.in
@@ -6,7 +6,6 @@ include(CMakeFindDependencyMacro)
 find_dependency(ers)
 find_dependency(logging)
 find_dependency(cetlib)
-find_dependency(serialization)
 
 if (EXISTS ${CMAKE_SOURCE_DIR}/@PROJECT_NAME@)
 


### PR DESCRIPTION
…ould also be added to detchannelmapsConfig.cmake.in, dropping a dependency means it should be dropped from detchannelmapsConfig.cmake.in