### PR TITLE
Include logging/Logging.hpp whenever ERS issues are declared, includi…

### DIFF
--- a/include/detchannelmaps/TPCChannelMap.hpp
+++ b/include/detchannelmaps/TPCChannelMap.hpp
@@ -4,6 +4,7 @@
 #include "cetlib/BasicPluginFactory.h"
 #include "cetlib/compiler_macros.h"
 #include "ers/Issue.hpp"
+#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 #include <optional>
 
 

--- a/include/detchannelmaps/TPCChannelMap.hpp
+++ b/include/detchannelmaps/TPCChannelMap.hpp
@@ -4,7 +4,7 @@
 #include "cetlib/BasicPluginFactory.h"
 #include "cetlib/compiler_macros.h"
 #include "ers/Issue.hpp"
-#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
+#include "logging/Logging.hpp" // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 #include <optional>
 
 

--- a/test/plugins/DummyChannelMap.cpp
+++ b/test/plugins/DummyChannelMap.cpp
@@ -14,7 +14,7 @@
 #include "detchannelmaps/TPCChannelMap.hpp"
 
 #include "ers/Issue.hpp"
-#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
+#include "logging/Logging.hpp" // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 
 #include <string>
 #include <vector>

--- a/test/plugins/DummyChannelMap.cpp
+++ b/test/plugins/DummyChannelMap.cpp
@@ -14,6 +14,7 @@
 #include "detchannelmaps/TPCChannelMap.hpp"
 
 #include "ers/Issue.hpp"
+#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 
 #include <string>
 #include <vector>


### PR DESCRIPTION
…ng note on why (TLOG() << ERSIssue only works when Logging.hpp included first)