### PR TITLE
JCF: since the detchannelmaps library depends on fmt, make sure that …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(detchannelmaps VERSION 1.8.0)
+project(detchannelmaps VERSION 1.8.1)
 
 find_package(daq-cmake REQUIRED)
 find_package(cetlib REQUIRED)   # Uses the daq-buildtools/cmake/Findcetlib.cmake

--- a/cmake/detchannelmapsConfig.cmake.in
+++ b/cmake/detchannelmapsConfig.cmake.in
@@ -6,6 +6,7 @@ include(CMakeFindDependencyMacro)
 find_dependency(ers)
 find_dependency(logging)
 find_dependency(cetlib)
+find_dependency(fmt)
 
 if (EXISTS ${CMAKE_SOURCE_DIR}/@PROJECT_NAME@)
 


### PR DESCRIPTION
…fmt gets pulled in when find_package(detchannelmaps REQUIRED) gets called